### PR TITLE
fix(#0019): resolve all mypy type safety errors in test suite

### DIFF
--- a/tests/test_default_character.py
+++ b/tests/test_default_character.py
@@ -85,6 +85,7 @@ class TestDefaultCharacter(unittest.TestCase):
                     default_char_data,
                     f"Font '{font_name}' has None for default character data",
                 )
+                assert default_char_data is not None  # Type narrowing for mypy
 
                 lines = default_char_data.lines
 
@@ -111,6 +112,7 @@ class TestDefaultCharacter(unittest.TestCase):
                     default_char_data,
                     f"Font '{font_name}' has None for default character data",
                 )
+                assert default_char_data is not None  # Type narrowing for mypy
 
                 width = default_char_data.width
                 self.assertIsInstance(
@@ -140,6 +142,7 @@ class TestDefaultCharacter(unittest.TestCase):
                     default_char_data,
                     f"Font '{font_name}' has None for default character data",
                 )
+                assert default_char_data is not None  # Type narrowing for mypy
 
                 lines = default_char_data.lines
                 actual_height = len(lines)

--- a/tests/test_digits_completeness.py
+++ b/tests/test_digits_completeness.py
@@ -53,6 +53,7 @@ class TestDigitsCompleteness(unittest.TestCase):
                     char_data,
                     f"Font '{font_name}' character '{digit}' returned None data",
                 )
+                assert char_data is not None  # Type narrowing for mypy
 
                 # Must have lines attribute
                 self.assertTrue(

--- a/tests/test_extra_characters_completeness.py
+++ b/tests/test_extra_characters_completeness.py
@@ -72,6 +72,7 @@ class TestExtraCharactersCompleteness(unittest.TestCase):
                     char_data,
                     f"Font '{font_name}' character {repr(char)} returned None data",
                 )
+                assert char_data is not None  # Type narrowing for mypy
 
                 # Must have lines attribute
                 self.assertTrue(
@@ -223,6 +224,7 @@ class TestExtraCharactersCompleteness(unittest.TestCase):
                         char_data,
                         f"Font '{font_name}' space character returned None data",
                     )
+                    assert char_data is not None  # Type narrowing for mypy
 
                     # Space should have lines
                     self.assertTrue(

--- a/tests/test_font_completeness.py
+++ b/tests/test_font_completeness.py
@@ -51,6 +51,7 @@ class TestFontCompleteness(unittest.TestCase):
                             char_data,
                             f"Font '{font_name}' missing character data for '{char}'",
                         )
+                        assert char_data is not None  # Type narrowing for mypy
                         self.assertGreater(
                             len(char_data.lines),
                             0,
@@ -87,6 +88,7 @@ class TestFontCompleteness(unittest.TestCase):
                             char_data,
                             f"Font '{font_name}' missing character data for '{char}'",
                         )
+                        assert char_data is not None  # Type narrowing for mypy
                         self.assertGreater(
                             len(char_data.lines),
                             0,
@@ -123,6 +125,7 @@ class TestFontCompleteness(unittest.TestCase):
                             char_data,
                             f"Font '{font_name}' missing character data for '{char}'",
                         )
+                        assert char_data is not None  # Type narrowing for mypy
                         self.assertGreater(
                             len(char_data.lines),
                             0,
@@ -184,6 +187,7 @@ class TestFontCompleteness(unittest.TestCase):
                 self.assertIsNotNone(
                     space_data, f"Font '{font_name}' missing character data for space"
                 )
+                assert space_data is not None  # Type narrowing for mypy
                 self.assertGreater(
                     len(space_data.lines),
                     0,

--- a/tests/test_font_height_consistency.py
+++ b/tests/test_font_height_consistency.py
@@ -48,6 +48,7 @@ class TestFontHeightConsistency(unittest.TestCase):
                             char_data,
                             f"Font '{font_name}' character '{char}' returned None data",
                         )
+                        assert char_data is not None  # Type narrowing for mypy
 
                         self.assertTrue(
                             hasattr(char_data, "lines"),
@@ -107,6 +108,7 @@ class TestFontHeightConsistency(unittest.TestCase):
                             char_data,
                             f"Font '{font_name}' character '{char}' returned None data",
                         )
+                        assert char_data is not None  # Type narrowing for mypy
 
                         lines = char_data.lines
 
@@ -179,6 +181,7 @@ class TestFontHeightConsistency(unittest.TestCase):
                             char_data,
                             f"Font '{font_name}' character '{char}' returned None data",
                         )
+                        assert char_data is not None  # Type narrowing for mypy
 
                         lines = char_data.lines
                         self.assertGreater(

--- a/tests/test_font_validation.py
+++ b/tests/test_font_validation.py
@@ -29,7 +29,7 @@ class TestFontValidation(unittest.TestCase):
     def test_all_fonts_have_correct_character_line_counts(self):
         """Test that all characters in each font have the correct number of lines."""
         # Known issues in legacy fonts that we're not fixing in this project
-        known_issues = {}
+        known_issues: dict[tuple[str, str], int] = {}
 
         for font_name in get_available_fonts():
             expected_height = get_font_height(font_name)

--- a/tests/test_space_character_validation.py
+++ b/tests/test_space_character_validation.py
@@ -51,6 +51,7 @@ class TestSpaceCharacterValidation(unittest.TestCase):
                     space_char,
                     f"Font '{font_name}' does not have space character (' ') defined",
                 )
+                assert space_char is not None  # Type narrowing for mypy
 
                 # Verify trim flag is False
                 self.assertFalse(
@@ -66,6 +67,12 @@ class TestSpaceCharacterValidation(unittest.TestCase):
             with self.subTest(font=font_name):
                 font = create_font(font_name)
                 space_char = font.get_character(" ")
+
+                # Verify space character exists
+                self.assertIsNotNone(
+                    space_char, f"Font '{font_name}' space character not found"
+                )
+                assert space_char is not None  # Type narrowing for mypy
 
                 # Verify space character has lines
                 self.assertIsNotNone(
@@ -95,6 +102,12 @@ class TestSpaceCharacterValidation(unittest.TestCase):
             with self.subTest(font=font_name):
                 font = create_font(font_name)
                 space_char = font.get_character(" ")
+
+                # Verify space character exists
+                self.assertIsNotNone(
+                    space_char, f"Font '{font_name}' space character not found"
+                )
+                assert space_char is not None  # Type narrowing for mypy
 
                 # Verify space character has positive width
                 self.assertGreater(

--- a/tests/test_uppercase_completeness.py
+++ b/tests/test_uppercase_completeness.py
@@ -53,6 +53,7 @@ class TestUppercaseCompleteness(unittest.TestCase):
                     char_data,
                     f"Font '{font_name}' character '{letter}' returned None data",
                 )
+                assert char_data is not None  # Type narrowing for mypy
 
                 # Must have lines attribute
                 self.assertTrue(


### PR DESCRIPTION
## Summary
- Add proper None checks before accessing CharacterData attributes in all test files
- Fix missing type annotation for known_issues dict in test_font_validation.py
- Ensure all test files pass mypy type checking
- All tests continue to pass after fixes

## Test plan
- [x] All 64 tests pass
- [x] All mypy type errors resolved (from 35 to 0)
- [x] No regression in test coverage

Closes #19 