### PR TITLE
feat(#0023): rename 'default' font to 'classic' for better descriptive naming

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 
 ## @dev
 
+- [#0023] Renamed 'default' font to 'classic' for better descriptive naming
 - [#0022] Add < and > characters to all fonts that were missing them
 - Enhanced font character support with additional punctuation and symbols across all fonts
 

--- a/src/banger/cli.py
+++ b/src/banger/cli.py
@@ -73,23 +73,23 @@ def create_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
-    # Load configuration classics
+    # Load configuration defaults
     config = get_config()
-    classic_font = config.get_font() or "quadrant"
+    default_font = config.get_font() or "quadrant"
 
     available_fonts = get_available_fonts()
     parser.add_argument(
         "--font",
-        classic=classic_font,
+        default=default_font,
         choices=available_fonts,
-        help="Built-in font to use for rendering (classic: %(classic)s).",
+        help="Built-in font to use for rendering (default: %(default)s).",
     )
 
     parser.add_argument(
         "--banner-width",
         type=int,
         metavar="CHARS",
-        help="Maximum total banner width in characters (classic: auto-detect terminal width)",
+        help="Maximum total banner width in characters (default: auto-detect terminal width)",
     )
 
     def positive_int(value):
@@ -104,7 +104,7 @@ def create_parser() -> argparse.ArgumentParser:
         "--width",
         type=positive_int,
         metavar="CHARS",
-        help="Minimum recommended width for each character (classic: use characters' real width)",
+        help="Minimum recommended width for each character (default: use characters' real width)",
     )
 
     parser.add_argument(
@@ -141,15 +141,15 @@ def create_parser() -> argparse.ArgumentParser:
         "--ttf-size",
         type=positive_int,
         metavar="SIZE",
-        help="TTF font size in points (classic: auto-calculated based on --ttf-lines)",
+        help="TTF font size in points (default: auto-calculated based on --ttf-lines)",
     )
 
     parser.add_argument(
         "--ttf-lines",
         type=positive_int,
-        classic=7,
+        default=7,
         metavar="LINES",
-        help="Output height in terminal lines (classic: %(classic)s)",
+        help="Output height in terminal lines (default: %(default)s)",
     )
 
     parser.add_argument(
@@ -161,9 +161,9 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--ttf-list-sort",
         choices=["name", "path"],
-        classic="path",
+        default="path",
         metavar="SORT",
-        help="Sort TTF/OTF font list by name or path (classic: %(classic)s)",
+        help="Sort TTF/OTF font list by name or path (default: %(default)s)",
     )
 
     parser.add_argument(
@@ -296,7 +296,7 @@ def main() -> int:
         if not text_args:
             parser.error("argument text: expected at least one argument after --")
 
-        # Create a minimal args object with config classics
+        # Create a minimal args object with config defaults
         config = get_config()
 
         class Args:

--- a/src/banger/cli.py
+++ b/src/banger/cli.py
@@ -73,23 +73,23 @@ def create_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
-    # Load configuration defaults
+    # Load configuration classics
     config = get_config()
-    default_font = config.get_font() or "quadrant"
+    classic_font = config.get_font() or "quadrant"
 
     available_fonts = get_available_fonts()
     parser.add_argument(
         "--font",
-        default=default_font,
+        classic=classic_font,
         choices=available_fonts,
-        help="Built-in font to use for rendering (default: %(default)s).",
+        help="Built-in font to use for rendering (classic: %(classic)s).",
     )
 
     parser.add_argument(
         "--banner-width",
         type=int,
         metavar="CHARS",
-        help="Maximum total banner width in characters (default: auto-detect terminal width)",
+        help="Maximum total banner width in characters (classic: auto-detect terminal width)",
     )
 
     def positive_int(value):
@@ -104,7 +104,7 @@ def create_parser() -> argparse.ArgumentParser:
         "--width",
         type=positive_int,
         metavar="CHARS",
-        help="Minimum recommended width for each character (default: use characters' real width)",
+        help="Minimum recommended width for each character (classic: use characters' real width)",
     )
 
     parser.add_argument(
@@ -141,15 +141,15 @@ def create_parser() -> argparse.ArgumentParser:
         "--ttf-size",
         type=positive_int,
         metavar="SIZE",
-        help="TTF font size in points (default: auto-calculated based on --ttf-lines)",
+        help="TTF font size in points (classic: auto-calculated based on --ttf-lines)",
     )
 
     parser.add_argument(
         "--ttf-lines",
         type=positive_int,
-        default=7,
+        classic=7,
         metavar="LINES",
-        help="Output height in terminal lines (default: %(default)s)",
+        help="Output height in terminal lines (classic: %(classic)s)",
     )
 
     parser.add_argument(
@@ -161,9 +161,9 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--ttf-list-sort",
         choices=["name", "path"],
-        default="path",
+        classic="path",
         metavar="SORT",
-        help="Sort TTF/OTF font list by name or path (default: %(default)s)",
+        help="Sort TTF/OTF font list by name or path (classic: %(classic)s)",
     )
 
     parser.add_argument(
@@ -296,12 +296,12 @@ def main() -> int:
         if not text_args:
             parser.error("argument text: expected at least one argument after --")
 
-        # Create a minimal args object with config defaults
+        # Create a minimal args object with config classics
         config = get_config()
 
         class Args:
             def __init__(self):
-                self.font = config.get_font() or "default"
+                self.font = config.get_font() or "classic"
                 self.banner_width = config.get_banner_width()
                 self.width = config.get_width()
                 self.demo = False

--- a/src/banger/config.py
+++ b/src/banger/config.py
@@ -51,19 +51,19 @@ class Config:
             with open(config_path, "r", encoding="utf-8") as f:
                 self.config_data = yaml.safe_load(f) or {}
         except (yaml.YAMLError, OSError):
-            # Silently ignore config file errors - use classics
+            # Silently ignore config file errors - use defaults
             self.config_data = {}
 
     def get_font(self) -> Optional[str]:
-        """Get the classic font from configuration."""
+        """Get the default font from configuration."""
         return self.config_data.get("font")
 
     def get_banner_width(self) -> Optional[int]:
-        """Get the classic banner width from configuration."""
+        """Get the default banner width from configuration."""
         return self.config_data.get("banner_width")
 
     def get_width(self) -> Optional[int]:
-        """Get the classic character width from configuration."""
+        """Get the default character width from configuration."""
         return self.config_data.get("width")
 
 
@@ -126,7 +126,7 @@ def create_config_template(force: bool = False) -> bool:
             f.write(template_content)
 
         print(f"Configuration template created at: {config_path}")
-        print("Edit this file to customize your classic settings.")
+        print("Edit this file to customize your default settings.")
         return True
 
     except OSError as e:

--- a/src/banger/config.py
+++ b/src/banger/config.py
@@ -51,19 +51,19 @@ class Config:
             with open(config_path, "r", encoding="utf-8") as f:
                 self.config_data = yaml.safe_load(f) or {}
         except (yaml.YAMLError, OSError):
-            # Silently ignore config file errors - use defaults
+            # Silently ignore config file errors - use classics
             self.config_data = {}
 
     def get_font(self) -> Optional[str]:
-        """Get the default font from configuration."""
+        """Get the classic font from configuration."""
         return self.config_data.get("font")
 
     def get_banner_width(self) -> Optional[int]:
-        """Get the default banner width from configuration."""
+        """Get the classic banner width from configuration."""
         return self.config_data.get("banner_width")
 
     def get_width(self) -> Optional[int]:
-        """Get the default character width from configuration."""
+        """Get the classic character width from configuration."""
         return self.config_data.get("width")
 
 
@@ -110,7 +110,7 @@ def create_config_template(force: bool = False) -> bool:
 # Place this file at ~/.config/banger/banger.yml
 
 # Default font to use
-# Available fonts: default, matrix, banner, block, blur, compact, fire, quadrant, small
+# Available fonts: classic, matrix, banner, block, blur, compact, fire, quadrant, small
 # font: quadrant
 
 # Default banner width in characters (auto-detects terminal width if not specified)
@@ -126,7 +126,7 @@ def create_config_template(force: bool = False) -> bool:
             f.write(template_content)
 
         print(f"Configuration template created at: {config_path}")
-        print("Edit this file to customize your default settings.")
+        print("Edit this file to customize your classic settings.")
         return True
 
     except OSError as e:

--- a/src/banger/core.py
+++ b/src/banger/core.py
@@ -101,7 +101,7 @@ class BannerGenerator:
             char_data = self._font_obj.get_character(char)
             if char_data is None:
                 # Try to get default character as fallback
-                char_data = self._font_obj.get_character("default")
+                char_data = self._font_obj.get_character("classic")
                 if char_data is None:
                     raise RuntimeError(
                         f"TTF font missing both character '{char}' and 'default' fallback"
@@ -111,7 +111,7 @@ class BannerGenerator:
             char_data = _get_character_data_object(char, self.font)
             if char_data is None:
                 # Try to get default character as fallback
-                char_data = _get_character_data_object("default", self.font)
+                char_data = _get_character_data_object("classic", self.font)
                 if char_data is None:
                     raise RuntimeError(
                         f"Font '{self.font}' missing both character '{char}' and 'default' fallback"

--- a/src/banger/fonts/__init__.py
+++ b/src/banger/fonts/__init__.py
@@ -25,7 +25,7 @@ from .core import (
 )
 
 # Import fonts
-from .default import DefaultFont
+from .classic import ClassicFont
 from .matrix import MatrixFont
 
 # Import factory functions
@@ -65,7 +65,7 @@ __all__ = [
     "calculate_character_width",
     "normalize_character_lines",
     # Built-in fonts
-    "DefaultFont",
+    "ClassicFont",
     "MatrixFont",
     # Factory
     "create_font",

--- a/src/banger/fonts/classic.py
+++ b/src/banger/fonts/classic.py
@@ -13,17 +13,17 @@
 
 from .core import BaseFont
 
-"""Default built-in font."""
+"""Classic built-in font."""
 
 
-class DefaultFont(BaseFont):
-    """Default built-in font.
+class ClassicFont(BaseFont):
+    """Classic built-in font.
 
     Classic ASCII art font with 7-line height
     """
 
     _FONT_DATA = {
-        "name": "default",
+        "name": "classic",
         "height": 7,
         "description": "Classic ASCII art font with 7-line height",
         "bottom_padding": 1,

--- a/src/banger/fonts/factory.py
+++ b/src/banger/fonts/factory.py
@@ -18,7 +18,7 @@ from .block import BlockFont
 from .blur import BlurFont
 from .compact import CompactFont
 from .core import FontInterface
-from .default import DefaultFont
+from .classic import ClassicFont
 from .fire import FireFont
 from .matrix import MatrixFont
 from .quadrant import QuadrantFont
@@ -29,7 +29,7 @@ from .small import SmallFont
 
 # Font factory - maps font names to factory functions
 BUILTIN_FONTS: Dict[str, Callable[[], FontInterface]] = {
-    "default": lambda: DefaultFont(),
+    "classic": lambda: ClassicFont(),
     "matrix": lambda: MatrixFont(),
     "banner": lambda: BannerFont(),
     "block": lambda: BlockFont(),
@@ -54,8 +54,8 @@ def create_font(name: str) -> FontInterface:
     if name in BUILTIN_FONTS:
         return BUILTIN_FONTS[name]()
 
-    # Fallback to default
-    return BUILTIN_FONTS["default"]()
+    # Fallback to classic
+    return BUILTIN_FONTS["classic"]()
 
 
 def get_available_fonts() -> List[str]:

--- a/tests/test_default_character.py
+++ b/tests/test_default_character.py
@@ -51,7 +51,7 @@ class TestDefaultCharacter(unittest.TestCase):
         for font_name in get_available_fonts():
             with self.subTest(font=font_name):
                 font = create_font(font_name)
-                default_char_data = font.get_character("default")
+                default_char_data = font.get_character("classic")
 
                 self.assertIsNotNone(
                     default_char_data,
@@ -79,7 +79,7 @@ class TestDefaultCharacter(unittest.TestCase):
         for font_name in get_available_fonts():
             with self.subTest(font=font_name):
                 font = create_font(font_name)
-                default_char_data = font.get_character("default")
+                default_char_data = font.get_character("classic")
 
                 self.assertIsNotNone(
                     default_char_data,
@@ -106,7 +106,7 @@ class TestDefaultCharacter(unittest.TestCase):
         for font_name in get_available_fonts():
             with self.subTest(font=font_name):
                 font = create_font(font_name)
-                default_char_data = font.get_character("default")
+                default_char_data = font.get_character("classic")
 
                 self.assertIsNotNone(
                     default_char_data,
@@ -137,7 +137,7 @@ class TestDefaultCharacter(unittest.TestCase):
                 font = create_font(font_name)
                 expected_height = font.height
 
-                default_char_data = font.get_character("default")
+                default_char_data = font.get_character("classic")
                 self.assertIsNotNone(
                     default_char_data,
                     f"Font '{font_name}' has None for default character data",

--- a/tests/test_digits_completeness.py
+++ b/tests/test_digits_completeness.py
@@ -174,7 +174,7 @@ class TestDigitsCompleteness(unittest.TestCase):
 
         Default font must have complete digits support.
         """
-        self._validate_font_digits_completeness("default")
+        self._validate_font_digits_completeness("classic")
 
 
 if __name__ == "__main__":

--- a/tests/test_extra_characters_completeness.py
+++ b/tests/test_extra_characters_completeness.py
@@ -204,7 +204,7 @@ class TestExtraCharactersCompleteness(unittest.TestCase):
 
         Default font should have good extra characters support.
         """
-        self._validate_font_extra_characters_completeness("default")
+        self._validate_font_extra_characters_completeness("classic")
 
     def test_space_character_special_handling(self):
         """Test that space character has special handling across fonts.
@@ -275,7 +275,7 @@ class TestExtraCharactersCompleteness(unittest.TestCase):
             font_extra_chars = [
                 c
                 for c in chars
-                if c not in letters and c not in digits and c != "default"
+                if c not in letters and c not in digits and c != "classic"
             ]
             all_extra_chars.update(font_extra_chars)
 

--- a/tests/test_font_character_validation.py
+++ b/tests/test_font_character_validation.py
@@ -62,7 +62,7 @@ class TestFontCharacterValidation(unittest.TestCase):
     def test_validate_font_character_coverage_structure(self):
         """Test that font validation returns expected data structure."""
         # Test with default font (should be complete)
-        result = validate_font_character_coverage("default")
+        result = validate_font_character_coverage("classic")
 
         # Check required keys are present
         required_keys = {
@@ -95,7 +95,7 @@ class TestFontCharacterValidation(unittest.TestCase):
 
     def test_default_font_completeness(self):
         """Test that default font has complete character coverage."""
-        result = validate_font_character_coverage("default")
+        result = validate_font_character_coverage("classic")
 
         self.assertTrue(
             result["is_complete"],
@@ -124,7 +124,7 @@ class TestFontCharacterValidation(unittest.TestCase):
 
         # Only test original JSON fonts for complete digit coverage
         json_fonts = [
-            "default",
+            "classic",
             "block",
             "blur",
             "compact",
@@ -150,7 +150,7 @@ class TestFontCharacterValidation(unittest.TestCase):
 
         # Only test original JSON fonts for complete uppercase coverage
         json_fonts = [
-            "default",
+            "classic",
             "block",
             "blur",
             "compact",
@@ -232,7 +232,7 @@ class TestFontCharacterValidation(unittest.TestCase):
 
         # Only test original JSON fonts for complete critical character coverage
         json_fonts = [
-            "default",
+            "classic",
             "block",
             "blur",
             "compact",
@@ -269,7 +269,7 @@ class TestFontCharacterValidation(unittest.TestCase):
 
         # Only test original JSON fonts for minimum coverage
         json_fonts = [
-            "default",
+            "classic",
             "block",
             "blur",
             "compact",

--- a/tests/test_font_factory.py
+++ b/tests/test_font_factory.py
@@ -23,10 +23,10 @@ class TestFontFactory(unittest.TestCase):
 
     def test_create_font_with_valid_name(self):
         """Test that create_font creates valid font instances."""
-        font = create_font("default")
+        font = create_font("classic")
 
         self.assertIsNotNone(font)
-        self.assertEqual(font.name, "default")
+        self.assertEqual(font.name, "classic")
         self.assertGreater(font.height, 0)
 
     def test_create_font_with_invalid_name_falls_back_to_default(self):
@@ -34,12 +34,12 @@ class TestFontFactory(unittest.TestCase):
         font = create_font("nonexistent_font")
 
         self.assertIsNotNone(font)
-        self.assertEqual(font.name, "default")
+        self.assertEqual(font.name, "classic")
 
     def test_create_font_creates_new_instances(self):
         """Test that create_font creates new instances each time (no caching)."""
-        font1 = create_font("default")
-        font2 = create_font("default")
+        font1 = create_font("classic")
+        font2 = create_font("classic")
 
         self.assertIsNotNone(font1)
         self.assertIsNotNone(font2)
@@ -51,14 +51,14 @@ class TestFontFactory(unittest.TestCase):
 
         self.assertIsInstance(font_types, list)
         self.assertGreater(len(font_types), 0)
-        self.assertIn("default", font_types)
+        self.assertIn("classic", font_types)
 
     def test_get_available_font_types_contains_expected_fonts(self):
         """Test that get_available_font_types contains expected built-in fonts."""
         font_types = get_available_fonts()
 
         expected_fonts = [
-            "default",
+            "classic",
             "matrix",
             "banner",
             "block",
@@ -87,7 +87,7 @@ class TestFontFactory(unittest.TestCase):
 
     def test_font_instances_have_required_interface(self):
         """Test that created font instances implement required interface."""
-        font = create_font("default")
+        font = create_font("classic")
 
         # Test required properties
         self.assertTrue(hasattr(font, "name"))

--- a/tests/test_font_validation.py
+++ b/tests/test_font_validation.py
@@ -98,7 +98,7 @@ class TestFontValidation(unittest.TestCase):
         """Test that get_font_height returns the correct height for each font."""
         # Predefined expected heights for known fonts
         expected_heights = {
-            "default": 7,
+            "classic": 7,
             "quadrant": 5,
             "matrix": 5,
             "small": 5,
@@ -129,9 +129,9 @@ class TestFontValidation(unittest.TestCase):
     def test_get_character_data_returns_valid_structure(self):
         """Test that get_character_data returns properly structured data."""
         test_cases = [
-            ("A", "default"),
-            ("a", "default"),
-            ("0", "default"),
+            ("A", "classic"),
+            ("a", "classic"),
+            ("0", "classic"),
             ("A", "quadrant"),
             ("a", "quadrant"),
             ("0", "quadrant"),
@@ -278,7 +278,7 @@ class TestFontValidation(unittest.TestCase):
         )
 
         # Should have same data as default font
-        default_char_data = get_character_data("A", "default")
+        default_char_data = get_character_data("A", "classic")
         self.assertEqual(
             char_data["lines"],
             default_char_data["lines"],
@@ -296,7 +296,7 @@ class TestFontValidation(unittest.TestCase):
 
         for char in unknown_chars:
             with self.subTest(char=char):
-                char_data = get_character_data(char, "default")
+                char_data = get_character_data(char, "classic")
                 # Most unknown characters should return None (original behavior)
                 # Some might be handled, so we just test that it doesn't crash
                 if char_data is not None:

--- a/tests/test_uppercase_completeness.py
+++ b/tests/test_uppercase_completeness.py
@@ -174,7 +174,7 @@ class TestUppercaseCompleteness(unittest.TestCase):
 
         Default font must have complete uppercase support.
         """
-        self._validate_font_uppercase_completeness("default")
+        self._validate_font_uppercase_completeness("classic")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Rename the misleadingly named 'default' font to 'classic' to better reflect its visual style and eliminate confusion about its role in the system.

Closes #23